### PR TITLE
Fix bugs

### DIFF
--- a/src/app/api/game/insert-game/route.ts
+++ b/src/app/api/game/insert-game/route.ts
@@ -1,6 +1,7 @@
 import { db } from "@/database/db";
 import { gamesTable } from "@/database/schemas/gamesTable";
 import { createClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
@@ -68,6 +69,9 @@ export async function POST(request: Request) {
       timePlayed,
       userId,
     });
+
+    revalidatePath("/play");
+    revalidatePath("/analytics");
 
     return NextResponse.json(
       { message: "Game inserted successfully" },

--- a/src/app/api/settings/update-settings/route.ts
+++ b/src/app/api/settings/update-settings/route.ts
@@ -2,6 +2,7 @@ import { db } from "@/database/db";
 import { settingsTable } from "@/database/schemas/settingsTable";
 import { createClient } from "@/lib/supabase/server";
 import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
@@ -32,6 +33,7 @@ export async function POST(request: Request) {
       .set({ showFeedback: body.showFeedback })
       .where(eq(settingsTable.userId, userId));
 
+    revalidatePath("/settings");
     return NextResponse.json(
       { message: "Settings updated successfully" },
       { status: 200 },


### PR DESCRIPTION
This pull request includes updates to the `src/app/api/game/insert-game/route.ts` and `src/app/api/settings/update-settings/route.ts` files to add cache revalidation for specific paths after certain operations.

Cache revalidation:

* Added `revalidatePath` import from `next/cache` in `src/app/api/game/insert-game/route.ts` and `src/app/api/settings/update-settings/route.ts` to ensure cache is updated after changes. [[1]](diffhunk://#diff-daae9150f67da9fe43efc87aa625a1cccbc12627a66f7acd2fcdc634747506b5R4) [[2]](diffhunk://#diff-19847966c8d840a67f0a6dcf2b2a7943d5390b46fd485c1485c0a69e14cde56bR5)
* Added calls to `revalidatePath` for `/play` and `/analytics` paths in the `POST` function of `src/app/api/game/insert-game/route.ts` to refresh cache after a game is inserted.
* Added a call to `revalidatePath` for the `/settings` path in the `POST` function of `src/app/api/settings/update-settings/route.ts` to refresh cache after settings are updated.